### PR TITLE
Fix examples to require by path

### DIFF
--- a/examples/joke.js
+++ b/examples/joke.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Wit = require('node-wit').Wit;
+const Wit = require('../').Wit;
 
 const token = (() => {
   if (process.argv.length !== 3) {

--- a/examples/weather.js
+++ b/examples/weather.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Wit = require('node-wit').Wit;
+const Wit = require('../').Wit;
 
 const token = (() => {
   if (process.argv.length !== 3) {


### PR DESCRIPTION
After cloning the repo and running `$ npm install`, when I run the examples locally I was getting this error:

``` bash
$ node examples/joke.js <apiKey>
module.js:339
    throw err;
    ^

Error: Cannot find module 'node-wit'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/home/jedireza/playground/node-wit/examples/joke.js:3:13)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
```

I tried to install `node-wit` but `npm` complains:

``` bash
$ npm install node-wit
npm WARN package.json node-wit@3.0.0 No license field.
npm WARN install Refusing to install node-wit as a dependency of itself
```

So in order to run the examples I had to require by path instead of module name.
