### PR TITLE
Fix Facebook page token env variable name

### DIFF
--- a/examples/messenger.js
+++ b/examples/messenger.js
@@ -29,7 +29,7 @@ const FB_PAGE_ID = process.env.FB_PAGE_ID && Number(process.env.FB_PAGE_ID);
 if (!FB_PAGE_ID) {
   throw new Error('missing FB_PAGE_ID');
 }
-const FB_PAGE_TOKEN = process.env.FB_TOKEN;
+const FB_PAGE_TOKEN = process.env.FB_PAGE_TOKEN;
 if (!FB_PAGE_TOKEN) {
   throw new Error('missing FB_PAGE_TOKEN');
 }


### PR DESCRIPTION
According to the documentation and to the exception below, this env variable should be named `FB_PAGE_TOKEN`
