### PR TITLE
Handle Array values in clone of context

### DIFF
--- a/lib/wit.js
+++ b/lib/wit.js
@@ -89,11 +89,19 @@ const cbIfActionMissing = (actions, action, cb) => {
 };
 
 const clone = (obj) => {
-  const newObj = {};
-  Object.keys(obj).forEach(k => {
-    newObj[k] = typeof obj[k] === 'object' ? clone(obj[k]) : obj[k];
-  });
-  return newObj;
+  if (typeof obj === 'object') {
+    if (Array.isArray(obj)) {
+      return obj.map(clone);
+    } else {
+      const newObj = {};
+      Object.keys(obj).forEach(k => {
+        newObj[k] = clone(obj[k]);
+      });
+      return newObj;
+    }
+  } else {
+    return obj;
+  }
 };
 
 const Wit = function(token, actions, logger) {


### PR DESCRIPTION
Originally an array, such as `[1,2,3]` would be converted to the object:

```
{
0: 1,
1: 2,
2: 3
}
```

With this change to the clone method,
the context can allow having array values.
