### PR TITLE
Create readline interface only when interactive() is invoked.

### DIFF
--- a/lib/wit.js
+++ b/lib/wit.js
@@ -2,10 +2,6 @@
 
 const request = require('request');
 const readline = require('readline');
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
 const uuid = require('node-uuid');
 const Logger = require('./logger').Logger;
 const logLevels = require('./logger').logLevels;
@@ -265,9 +261,14 @@ const Wit = function(token, actions, logger) {
     const sessionId = uuid.v1();
     const context = typeof initContext === 'object' ? initContext : {};
     const steps = maxSteps ? maxSteps : DEFAULT_MAX_STEPS;
-    rl.setPrompt('> ');
-    rl.prompt();
-    rl.on('line', ((line) => {
+    this.rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    this.rl.setPrompt('> ');
+    this.rl.prompt();
+    this.rl.write(null, {ctrl: true, name: 'e'});
+    this.rl.on('line', ((line) => {
       const msg = line.trim();
       this.runActions(
         sessionId,
@@ -277,7 +278,8 @@ const Wit = function(token, actions, logger) {
           if (error) {
             l.error(error);
           }
-          rl.prompt();
+          this.rl.prompt();
+          this.rl.write(null, {ctrl: true, name: 'e'});
         },
         steps
       );


### PR DESCRIPTION
Readline interface should only be created when interactive() is invoked. Otherwise by creating on require of Wit causes issues with other apps already using readline interfaces.
