### PR TITLE
Pass an optional context parameter to the /message endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,13 @@ The Wit [message](https://wit.ai/docs/http/20160330#get-intent-via-text-link) AP
 
 Takes the following parameters:
 * `message` - the text you want Wit.ai to extract the information from
+* `context` - (optional) the object representing the session state
 * `cb(error, data)` - a callback function with the JSON response
 
 Example:
 ```js
-client.message('what is the weather in London?', (error, data) => {
+const context = {};
+client.message('what is the weather in London?', context, (error, data) => {
   if (error) {
     console.log('Oops! Got an error: ' + error);
   } else {

--- a/lib/wit.js
+++ b/lib/wit.js
@@ -114,12 +114,15 @@ const Wit = function(token, actions, logger) {
   }
   this.actions = validateActions(actions);
 
-  this.message = (message, cb) => {
+  this.message = (message, context, cb) => {
     const options = {
       uri: '/message',
       method: 'GET',
       qs: { q: message },
     };
+    if (context) {
+        options.qs.context = JSON.stringify(context);
+    }
     this.req(options, makeWitResponseHandler('message', l, cb));
   };
 

--- a/lib/wit.js
+++ b/lib/wit.js
@@ -121,7 +121,7 @@ const Wit = function(token, actions, logger) {
       qs: { q: message },
     };
     if (context) {
-        options.qs.context = JSON.stringify(context);
+      options.qs.context = JSON.stringify(context);
     }
     this.req(options, makeWitResponseHandler('message', l, cb));
   };


### PR DESCRIPTION
This is required so that Wit.ai is able to match intents with specific states defined.
