### PR TITLE
Remove context since `message()` does not take 3 params

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ Takes the following parameters:
 
 Example:
 ```js
-const context = {};
-client.message('what is the weather in London?', context, (error, data) => {
+client.message('what is the weather in London?', (error, data) => {
   if (error) {
     console.log('Oops! Got an error: ' + error);
   } else {


### PR DESCRIPTION
This is related to https://github.com/wit-ai/node-wit/issues/30

The readme mentions 3 params when it only takes two (message, cb)
