### PR TITLE
Change the signature check exception to a warn

### DIFF
--- a/lib/wit.js
+++ b/lib/wit.js
@@ -58,18 +58,19 @@ const validateActions = (actions) => {
   if (!actions.error) {
     throw new Error('The \'error\' action is missing. ' + learnMore);
   }
+  
   Object.keys(actions).forEach(key => {
     if (typeof actions[key] !== 'function') {
-      throw new Error('The \'' + key + '\' action should be a function.');
+      l.warn('The \'' + key + '\' action should be a function.');
     }
     if (key === 'say' && actions.say.length !== 4) {
-      throw new Error('The \'say\' action should accept 4 arguments: sessionId, context, message, callback. ' + learnMore);
+      l.warn('The \'say\' action should accept 4 arguments: sessionId, context, message, callback. ' + learnMore);
     } else if (key === 'merge' && actions.merge.length !== 5) {
-      throw new Error('The \'merge\' action should accept 5 arguments: sessionId, context, entities, message, callback. ' + learnMore);
+      l.warn('The \'merge\' action should accept 5 arguments: sessionId, context, entities, message, callback. ' + learnMore);
     } else if (key === 'error' && actions.error.length !== 3) {
-      throw new Error('The \'error\' action should accept 3 arguments: sessionId, context, error. ' + learnMore);
+      l.warn('The \'error\' action should accept 3 arguments: sessionId, context, error. ' + learnMore);
     } else if (key !== 'say' && key !== 'merge' && key !== 'error' && actions[key].length !== 3) {
-      throw new Error('The \'' + key + '\' action should accept 3 arguments: sessionId, context, callback. ' + learnMore);
+      l.warn('The \'' + key + '\' action should accept 3 arguments: sessionId, context, callback. ' + learnMore);
     }
   });
   return actions;


### PR DESCRIPTION
Changing the signature check failure states from an exception to a warning. 

This will allow client to use transpiling such as babel/bluebird.
