### PR TITLE
Fix #64. Check for bot's message

### DIFF
--- a/examples/messenger.js
+++ b/examples/messenger.js
@@ -167,7 +167,7 @@ app.post('/webhook', (req, res) => {
   if (data.object === 'page') {
     data.entry.forEach(entry => {
       entry.messaging.forEach(event => {
-        if (event.message) {
+        if (event.message && !event.message.is_echo) {
           // Yay! We got a new message!
           // We retrieve the Facebook user ID of the sender
           const sender = event.sender.id;


### PR DESCRIPTION
Fix for 'Error: (#100) No matching user found' error for  bot's message.
