### PR TITLE
reset when new messages or errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,7 @@
-## v4.1.0
-
 ### Breaking changes
 
 - interactive is no longer a function on the `Wit` client. Instead, you require it from the library. `require('node-wit').interactive`
+- `runActions` now reset the last turn on new messages and errors.
 
 ## v4.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ### Breaking changes
 
 - interactive is no longer a function on the `Wit` client. Instead, you require it from the library. `require('node-wit').interactive`
-- `runActions` now reset the last turn on new messages and errors.
+- `runActions` now resets the last turn on new messages and errors.
 
 ## v4.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 - Support for different JS environments
+- `converse` now takes `reset` as an optional parameter
 
 ### Breaking changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,9 @@
-## v4.1.0
-
 - Support for different JS environments
 
 ### Breaking changes
 
-- interactive is no longer a function on the `Wit` client. Instead, you require it from the library. `require('node-wit').interactive`
+- `interactive` is no longer a function on the `Wit` client. Instead, you require it from the library: `require('node-wit').interactive`
+- `runActions` now reset the last turn on new messages and errors.
 
 ## v4.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## v4.1.0
 
+- Support for different JS environments
+
 ### Breaking changes
 
 - interactive is no longer a function on the `Wit` client. Instead, you require it from the library. `require('node-wit').interactive`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### Breaking changes
 
 - `interactive` is no longer a function on the `Wit` client. Instead, you require it from the library: `require('node-wit').interactive`
-- `runActions` now reset the last turn on new messages and errors.
+- `runActions` now resets the last turn on new messages and errors.
 
 ## v4.0.0
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Starts an interactive conversation with your bot.
 Example:
 ```js
 const {interactive} = require('node-wit');
-interactive(client)
+interactive(client);
 ```
 
 See the [docs](https://wit.ai/docs) for more information.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ client.message('what is the weather in London?', {})
 ### runActions
 
 A higher-level method to the Wit converse API.
+`runActions` resets the last turn on new messages and errors.
 
 Takes the following parameters:
 * `sessionId` - a unique identifier describing the user session
@@ -145,6 +146,7 @@ Takes the following parameters:
 * `sessionId` - a unique identifier describing the user session
 * `message` - the text received from the user
 * `context` - the object representing the session state
+* `reset` - (optional) whether to reset the last turn
 
 Example:
 ```js

--- a/lib/wit.js
+++ b/lib/wit.js
@@ -62,8 +62,8 @@ function Wit(opts) {
     ;
   };
 
-  const continueRunActions = (function(sessionId, currentRequest, message, prevContext, i) {
-    return (function(json) {
+  const continueRunActions = (sessionId, currentRequest, message, prevContext, i) => {
+    return (json) => {
       if (i < 0) {
         logger.warn('Max steps reached, stopping.');
         return prevContext;
@@ -105,7 +105,7 @@ function Wit(opts) {
           text: json.msg,
           quickreplies: json.quickreplies,
         };
-        return actions.send(request, response).then((function(ctx) {
+        return actions.send(request, response).then(ctx => {
           if (ctx) {
             throw new Error('Cannot update context after \'send\' action');
           }
@@ -115,10 +115,10 @@ function Wit(opts) {
           return this.converse(sessionId, null, prevContext).then(
             continueRunActions(sessionId, currentRequest, message, prevContext, i - 1)
           );
-        }).bind(this));
+        });
       } else if (json.type === 'action') {
         throwIfActionMissing(actions, json.action);
-        return actions[json.action](request).then((function(ctx) {
+        return actions[json.action](request).then(ctx => {
           const nextContext = ctx || {};
           if (currentRequest !== this._sessions[sessionId]) {
             return nextContext;
@@ -126,13 +126,13 @@ function Wit(opts) {
           return this.converse(sessionId, null, nextContext).then(
             continueRunActions(sessionId, currentRequest, message, nextContext, i - 1)
           );
-        }).bind(this));
+        });
       } else {
         logger.debug('unknown response type ' + json.type);
         throw new Error('unknown response type ' + json.type);
       }
-    }).bind(this);
-  }).bind(this);
+    };
+  };
 
   this.runActions = function(sessionId, message, context, maxSteps) {
     if (!actions) throwMustHaveActions();
@@ -144,12 +144,12 @@ function Wit(opts) {
     // All the previous ones are discarded (preemptive exit).
     const currentRequest = (this._sessions[sessionId] || 0) + 1;
     this._sessions[sessionId] = currentRequest;
-    const cleanup = (function(ctx) {
+    const cleanup = ctx => {
       if (currentRequest === this._sessions[sessionId]) {
         delete this._sessions[sessionId];
       }
       return ctx;
-    }).bind(this);
+    };
 
     return this.converse(sessionId, message, context, currentRequest > 1).then(
       continueRunActions(sessionId, currentRequest, message, context, steps)

--- a/lib/wit.js
+++ b/lib/wit.js
@@ -20,7 +20,7 @@ function Wit(opts) {
     accessToken, apiVersion, actions, headers, logger, witURL
   } = this.config = Object.freeze(validate(opts));
 
-  this.sessions = {};
+  this._sessions = {};
 
   this.message = (message, context) => {
     let qs = 'q=' + encodeURIComponent(message);
@@ -62,31 +62,33 @@ function Wit(opts) {
     ;
   };
 
-  const continueRunActions = (sessionId, index, message, prevContext, i) => {
-    return ({action, entities, msg, quickreplies, type}) => {
+  const continueRunActions = (function(sessionId, currentRequest, message, prevContext, i) {
+    return (function(json) {
       if (i < 0) {
         logger.warn('Max steps reached, stopping.');
         return prevContext;
       }
-      throwIfNotLastIndex(index, this.sessions[sessionId].index);
-      if (!type) {
+      if (currentRequest !== this._sessions[sessionId]) {
+        return prevContext;
+      }
+      if (!json.type) {
         throw new Error('Couldn\'t find type in Wit response');
       }
 
       logger.debug('Context: ' + JSON.stringify(prevContext));
-      logger.debug('Response type: ' + type);
+      logger.debug('Response type: ' + json.type);
 
       // backwards-compatibility with API version 20160516
-      if (type === 'merge') {
-        type = 'action';
-        action = 'merge';
+      if (json.type === 'merge') {
+        json.type = 'action';
+        json.action = 'merge';
       }
 
-      if (type === 'error') {
+      if (json.type === 'error') {
         throw new Error('Oops, I don\'t know what to do.');
       }
 
-      if (type === 'stop') {
+      if (json.type === 'stop') {
         return prevContext;
       }
 
@@ -94,57 +96,64 @@ function Wit(opts) {
         sessionId,
         context: clone(prevContext),
         text: message,
-        entities
+        entities: json.entities,
       };
 
-      if (type === 'msg') {
+      if (json.type === 'msg') {
         throwIfActionMissing(actions, 'send');
         const response = {
-          text: msg,
-          quickreplies,
+          text: json.msg,
+          quickreplies: json.quickreplies,
         };
-        return actions.send(request, response).then((ctx) => {
+        return actions.send(request, response).then((function(ctx) {
           if (ctx) {
             throw new Error('Cannot update context after \'send\' action');
           }
-          throwIfNotLastIndex(index, this.sessions[sessionId].index);
+          if (currentRequest !== this._sessions[sessionId]) {
+            return ctx;
+          }
           return this.converse(sessionId, null, prevContext).then(
-            continueRunActions(sessionId, index, message, prevContext, i - 1)
+            continueRunActions(sessionId, currentRequest, message, prevContext, i - 1)
           );
-        });
-      } else if (type === 'action') {
-        throwIfActionMissing(actions, action);
-        return actions[action](request).then((ctx) => {
-          throwIfNotLastIndex(index, this.sessions[sessionId].index);
+        }).bind(this));
+      } else if (json.type === 'action') {
+        throwIfActionMissing(actions, json.action);
+        return actions[json.action](request).then((function(ctx) {
           const nextContext = ctx || {};
+          if (currentRequest !== this._sessions[sessionId]) {
+            return nextContext;
+          }
           return this.converse(sessionId, null, nextContext).then(
-            continueRunActions(sessionId, index, message, nextContext, i - 1)
+            continueRunActions(sessionId, currentRequest, message, nextContext, i - 1)
           );
-        });
+        }).bind(this));
       } else {
-        logger.debug('unknown response type ' + type);
-        throw new Error('unknown response type ' + type);
+        logger.debug('unknown response type ' + json.type);
+        throw new Error('unknown response type ' + json.type);
       }
-    }
-  };
+    }).bind(this);
+  }).bind(this);
 
-  this.runActions = (sessionId, message, context, maxSteps) => {
+  this.runActions = function(sessionId, message, context, maxSteps) {
     if (!actions) throwMustHaveActions();
-
-    let {index = 0, text = ''} = this.sessions[sessionId] || {};
-    ++index;
-    text = text === '' ? message : text + ' ' + message;
-    this.sessions[sessionId] = { index, text };
-
     const steps = maxSteps ? maxSteps : DEFAULT_MAX_STEPS;
-    return this.converse(sessionId, text, context, index > 1).then(
-      continueRunActions(sessionId, index, text, context, steps)
-    ).then((ctx) => {
-      if (index === this.sessions[sessionId].index) {
-        this.sessions[sessionId] = {};
+
+    // Figuring out whether we need to reset the last turn.
+    // Each new call increments an index for the session.
+    // We only care about the last call to runActions.
+    // All the previous ones are discarded (preemptive exit).
+    const currentRequest = (this._sessions[sessionId] || 0) + 1;
+    this._sessions[sessionId] = currentRequest;
+    const cleanup = (function(ctx) {
+      if (currentRequest === this._sessions[sessionId]) {
+        delete this._sessions[sessionId];
       }
       return ctx;
-    });
+    }).bind(this);
+
+    return this.converse(sessionId, message, context, currentRequest > 1).then(
+      continueRunActions(sessionId, currentRequest, message, context, steps)
+    ).then(cleanup);
   };
 };
 
@@ -183,12 +192,6 @@ const throwMustHaveActions = () => {
 const throwIfActionMissing = (actions, action) => {
   if (!actions[action]) {
     throw new Error('No \'' + action + '\' action found.');
-  }
-};
-
-const throwIfNotLastIndex = (index, lastIndex) => {
-  if (index !== lastIndex) {
-    throw new Error('runActions has restarted for this session!');
   }
 };
 

--- a/lib/wit.js
+++ b/lib/wit.js
@@ -20,6 +20,8 @@ function Wit(opts) {
     accessToken, apiVersion, actions, headers, logger, witURL
   } = this.config = Object.freeze(validate(opts));
 
+  this.sessions = {};
+
   this.message = (message, context) => {
     let qs = 'q=' + encodeURIComponent(message);
     if (context) {
@@ -38,10 +40,13 @@ function Wit(opts) {
     ;
   };
 
-  this.converse = (sessionId, message, context) => {
+  this.converse = (sessionId, message, context, reset) => {
     let qs = 'session_id=' + encodeURIComponent(sessionId);
     if (message) {
       qs += '&q=' + encodeURIComponent(message);
+    }
+    if (reset) {
+      qs += '&reset=true';
     }
     const method = 'POST';
     const fullURL = witURL + '/converse?' + qs;
@@ -57,30 +62,31 @@ function Wit(opts) {
     ;
   };
 
-  const continueRunActions = (sessionId, message, prevContext, i) => {
-    return (json) => {
+  const continueRunActions = (sessionId, index, message, prevContext, i) => {
+    return ({action, entities, msg, quickreplies, type}) => {
       if (i < 0) {
         logger.warn('Max steps reached, stopping.');
         return prevContext;
       }
-      if (!json.type) {
+      throwIfNotLastIndex(index, this.sessions[sessionId].index);
+      if (!type) {
         throw new Error('Couldn\'t find type in Wit response');
       }
 
       logger.debug('Context: ' + JSON.stringify(prevContext));
-      logger.debug('Response type: ' + json.type);
+      logger.debug('Response type: ' + type);
 
-      // backwards-cpmpatibility with API version 20160516
-      if (json.type === 'merge') {
-        json.type = 'action';
-        json.action = 'merge';
+      // backwards-compatibility with API version 20160516
+      if (type === 'merge') {
+        type = 'action';
+        action = 'merge';
       }
 
-      if (json.type === 'error') {
+      if (type === 'error') {
         throw new Error('Oops, I don\'t know what to do.');
       }
 
-      if (json.type === 'stop') {
+      if (type === 'stop') {
         return prevContext;
       }
 
@@ -88,45 +94,57 @@ function Wit(opts) {
         sessionId,
         context: clone(prevContext),
         text: message,
-        entities: json.entities,
+        entities
       };
 
-      if (json.type === 'msg') {
+      if (type === 'msg') {
         throwIfActionMissing(actions, 'send');
         const response = {
-          text: json.msg,
-          quickreplies: json.quickreplies,
+          text: msg,
+          quickreplies,
         };
         return actions.send(request, response).then((ctx) => {
           if (ctx) {
             throw new Error('Cannot update context after \'send\' action');
           }
+          throwIfNotLastIndex(index, this.sessions[sessionId].index);
           return this.converse(sessionId, null, prevContext).then(
-            continueRunActions(sessionId, message, prevContext, i - 1)
+            continueRunActions(sessionId, index, message, prevContext, i - 1)
           );
         });
-      } else if (json.type === 'action') {
-        const action = json.action;
+      } else if (type === 'action') {
         throwIfActionMissing(actions, action);
         return actions[action](request).then((ctx) => {
+          throwIfNotLastIndex(index, this.sessions[sessionId].index);
           const nextContext = ctx || {};
           return this.converse(sessionId, null, nextContext).then(
-            continueRunActions(sessionId, message, nextContext, i - 1)
+            continueRunActions(sessionId, index, message, nextContext, i - 1)
           );
         });
       } else {
-        logger.debug('unknown response type', json);
-        throw new Error('unknown response type ' + json.type);
+        logger.debug('unknown response type ' + type);
+        throw new Error('unknown response type ' + type);
       }
     }
   };
 
   this.runActions = (sessionId, message, context, maxSteps) => {
     if (!actions) throwMustHaveActions();
+
+    let {index = 0, text = ''} = this.sessions[sessionId] || {};
+    ++index;
+    text = text === '' ? message : text + ' ' + message;
+    this.sessions[sessionId] = { index, text };
+
     const steps = maxSteps ? maxSteps : DEFAULT_MAX_STEPS;
-    return this.converse(sessionId, message, context).then(
-      continueRunActions(sessionId, message, context, steps)
-    );
+    return this.converse(sessionId, text, context, index > 1).then(
+      continueRunActions(sessionId, index, text, context, steps)
+    ).then((ctx) => {
+      if (index === this.sessions[sessionId].index) {
+        this.sessions[sessionId] = {};
+      }
+      return ctx;
+    });
   };
 };
 
@@ -165,6 +183,12 @@ const throwMustHaveActions = () => {
 const throwIfActionMissing = (actions, action) => {
   if (!actions[action]) {
     throw new Error('No \'' + action + '\' action found.');
+  }
+};
+
+const throwIfNotLastIndex = (index, lastIndex) => {
+  if (index !== lastIndex) {
+    throw new Error('runActions has restarted for this session!');
   }
 };
 


### PR DESCRIPTION
- runActions to reset last turn on errors (robust) and new messages (async)
- concatenate last user messages with a space (alternatively, we could ignore all messages but the last one)
