### PR TITLE
[wit] support actions that do not return promises

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+- support the case where an action does not return a Promise
+- update uuid to version 3.0.0
+- Support older versions of node
+- 'Use strict' on interactive.js
+- Check for bot's message in messenger example
+
 ## v4.1.0
 
 - Support for different JS environments

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+- support actions that do not return promises
 - support the case where an action does not return a Promise
 - update uuid to version 3.0.0
 - Support older versions of node

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -23,11 +23,8 @@ const actions = {
   send(request, response) {
     const {sessionId, context, entities} = request;
     const {text, quickreplies} = response;
-    return new Promise(function(resolve, reject) {
-      console.log('user said...', request.text);
-      console.log('sending...', JSON.stringify(response));
-      return resolve();
-    });
+    console.log('user said...', request.text);
+    console.log('sending...', JSON.stringify(response));
   },
 };
 

--- a/examples/quickstart.js
+++ b/examples/quickstart.js
@@ -41,9 +41,8 @@ const actions = {
     console.log('sending...', JSON.stringify(response));
   },
   getForecast({context, entities}) {
-    var location = firstEntityValue(entities, 'location')
+    var location = firstEntityValue(entities, 'location');
     if (location) {
-      console.log('got', location)
       context.forecast = 'sunny in ' + location; // we should call a weather API here
       delete context.missingLocation;
     } else {

--- a/examples/quickstart.js
+++ b/examples/quickstart.js
@@ -38,23 +38,19 @@ const actions = {
   send(request, response) {
     const {sessionId, context, entities} = request;
     const {text, quickreplies} = response;
-    return new Promise(function(resolve, reject) {
-      console.log('sending...', JSON.stringify(response));
-      return resolve();
-    });
+    console.log('sending...', JSON.stringify(response));
   },
   getForecast({context, entities}) {
-    return new Promise(function(resolve, reject) {
-      var location = firstEntityValue(entities, 'location')
-      if (location) {
-        context.forecast = 'sunny in ' + location; // we should call a weather API here
-        delete context.missingLocation;
-      } else {
-        context.missingLocation = true;
-        delete context.forecast;
-      }
-      return resolve(context);
-    });
+    var location = firstEntityValue(entities, 'location')
+    if (location) {
+      console.log('got', location)
+      context.forecast = 'sunny in ' + location; // we should call a weather API here
+      delete context.missingLocation;
+    } else {
+      context.missingLocation = true;
+      delete context.forecast;
+    }
+    return context;
   },
 };
 

--- a/lib/wit.js
+++ b/lib/wit.js
@@ -97,14 +97,12 @@ function Wit(opts) {
         text: message,
         entities: json.entities,
       };
-
       if (json.type === 'msg') {
-        throwIfActionMissing(actions, 'send');
         const response = {
           text: json.msg,
           quickreplies: json.quickreplies,
         };
-        return actions.send(request, response).then(ctx => {
+        return runAction(actions, 'send', request, response).then(ctx => {
           if (ctx) {
             throw new Error('Cannot update context after \'send\' action');
           }
@@ -116,8 +114,7 @@ function Wit(opts) {
           );
         });
       } else if (json.type === 'action') {
-        throwIfActionMissing(actions, json.action);
-        return actions[json.action](request).then(ctx => {
+        return runAction(actions, json.action, request).then(ctx => {
           const nextContext = ctx || {};
           if (currentRequest !== this._sessions[sessionId]) {
             return nextContext;
@@ -136,7 +133,6 @@ function Wit(opts) {
   this.runActions = function(sessionId, message, context, maxSteps) {
     if (!actions) throwMustHaveActions();
     const steps = maxSteps ? maxSteps : DEFAULT_MAX_STEPS;
-
     // Figuring out whether we need to reset the last turn.
     // Each new call increments an index for the session.
     // We only care about the last call to runActions.
@@ -193,6 +189,11 @@ const throwIfActionMissing = (actions, action) => {
     throw new Error('No \'' + action + '\' action found.');
   }
 };
+
+const runAction = (actions, name, ...rest) => {
+  throwIfActionMissing(actions, name);
+  return Promise.resolve(actions[name](...rest));
+}
 
 const validate = (opts) => {
   if (!opts.accessToken) {

--- a/lib/wit.js
+++ b/lib/wit.js
@@ -193,7 +193,7 @@ const throwIfActionMissing = (actions, action) => {
 const runAction = (actions, name, ...rest) => {
   throwIfActionMissing(actions, name);
   return Promise.resolve(actions[name](...rest));
-}
+};
 
 const validate = (opts) => {
   if (!opts.accessToken) {


### PR DESCRIPTION
- make it so options do not need to return a promise.

the solution:
- use Promise.resolve -- (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve)

test plan:
- run the quickstart example -> 

```
  node examples/quickstart.js <TOKEN>
```

type "I want the weather in Paris"

see that the send action, and the getForecast action both work, without needing to return a promise

