### PR TITLE
Add confidence field to send method in runActions

### DIFF
--- a/lib/wit.js
+++ b/lib/wit.js
@@ -101,6 +101,7 @@ function Wit(opts) {
         const response = {
           text: json.msg,
           quickreplies: json.quickreplies,
+          confidence: json.confidence,
         };
         return runAction(actions, 'send', request, response).then(ctx => {
           if (ctx) {


### PR DESCRIPTION
This allows the app to send an "I'm not sure" style of message when the confidence is below a certain threshold