### PR TITLE
Added a more updated alternative to isomorphic-fetch.

### DIFF
--- a/lib/wit.js
+++ b/lib/wit.js
@@ -5,7 +5,7 @@ const {
   DEFAULT_MAX_STEPS,
   DEFAULT_WIT_URL
 } = require('./config');
-const fetch = require('isomorphic-fetch');
+const fetch = require('cross-fetch');
 const log = require('./log');
 
 const learnMore = 'Learn more at https://wit.ai/docs/quickstart';

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "repository": "https://github.com/wit-ai/node-wit",
   "author": "The Wit Team <help@wit.ai>",
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1",
+    "cross-fetch": "^1.1.0",
     "uuid": "^3.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,6 +847,13 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cross-fetch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-1.1.0.tgz#adcb4c4522411998408c3a1afeb928284c882175"
+  dependencies:
+    node-fetch "1.7.3"
+    whatwg-fetch "2.0.3"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -1255,13 +1262,6 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isomorphic-fetch@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
-
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -1466,9 +1466,9 @@ nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
-node-fetch@^1.0.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
+node-fetch@1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
@@ -1919,7 +1919,7 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 


### PR DESCRIPTION
isomorphic-fetch hasn't been updated for a while, so cross-fetch was created in order to provide a more updated, flexible and [fixed](https://github.com/matthew-andrews/isomorphic-fetch/issues/125) alternative to the community.
