### PR TITLE
Solves issue #169

### DIFF
--- a/lib/wit.js
+++ b/lib/wit.js
@@ -41,10 +41,13 @@ function Wit(opts) {
 
   this._sessions = {};
 
-  this.message = (message, context, n, verbose, junk) => {
+  this.message = (message, context, n, verbose, junk, msgId) => {
     let qs = 'q=' + encodeURIComponent(message);
     if (context) {
       qs += '&context=' + encodeURIComponent(JSON.stringify(context));
+    }
+    if (msgId) {
+      qs += `&msg_id=${encodeURIComponent(msgId)}`;
     }
     if (typeof n === 'number') {
       qs += '&n=' + encodeURIComponent(JSON.stringify(n));


### PR DESCRIPTION
# Solves Issue #169 

Now sending msg_id param in Method Wit.message() is possible.

