### PR TITLE
fix(package/bump): Update vulnerable packages without breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,17 +21,17 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "https-proxy-agent": "^5.0.0",
-    "isomorphic-fetch": "^2.2.1",
+    "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.14",
     "mic": "^2.1.2",
-    "uuid": "^3.0.0"
+    "uuid": "^9.0.0"
   },
   "engines": {
     "node": ">=6.17.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^3.5.3",
+    "mocha": "^6.2.2",
     "sinon": "^1.17.6"
   }
 }


### PR DESCRIPTION
`npm audit` complained about the following (sub)modules:

- `isomorphic-fetch`
- `uuid`
- `mocha`

I ran a local test with success after upgrading the modules.